### PR TITLE
Fix: ~= doesn't match tokens that are surrounded by spaces

### DIFF
--- a/lib/zest.js
+++ b/lib/zest.js
@@ -347,9 +347,7 @@ var operators = {
     f = attr[i - 1];
     l = attr[i + val.length];
 
-    return (f === ' ' && !l)
-        || (!f && l === ' ')
-        || (!f && !l);
+    return (!f || f === ' ') && (!l || l === ' ');
   },
   '|=': function(attr, val) {
     var i = attr.indexOf(val)

--- a/test/index.html
+++ b/test/index.html
@@ -16,8 +16,8 @@
     <header>
       <h1 id="hi"><a href="#">A Page</a></h1>
       <nav lang="en"><ul>
-        <li><a href="#" rel="section">A Link</a></li>
-        <li><a href="#" rel="section">A Link</a></li>
+        <li><a href="#" rel="section" class="foo bar">A Link</a></li>
+        <li><a href="#" rel="section" class="foo bar boo">A Link</a></li>
         <li><a href="#" rel="section">A Link</a></li>
         <li><a href="#" rel="section">A Link</a></li>
         <li><a href=#" rel="section">A Link</a></li>

--- a/test/test.js
+++ b/test/test.js
@@ -92,6 +92,7 @@ var runTests = function() {
   assert.selector('header h1');
   assert.selector('article p');
   assert.selector(':not(a)');
+  assert.selector('.bar');
   assert.selector('[id="hi"]');
   assert.selector('h1 + time[datetime]');
   assert.selector('h1 + time[datetime]:last-child');


### PR DESCRIPTION
See test-case for details.
