### PR TITLE
minor performance update for slice shim

### DIFF
--- a/lib/zest.js
+++ b/lib/zest.js
@@ -831,7 +831,7 @@ var find = function(sel, node) {
 var select = (function() {
   var slice = (function() {
     try {
-      Array.prototype.slice.call(document.getElementsByTagName('*'));
+      Array.prototype.slice.call(document.getElementsByTagName('zest'));
       return Array.prototype.slice;
     } catch(e) {
       e = null;


### PR DESCRIPTION
`document.getElementsByTagName('*')` is more expensive than need be.  IE will barf when attempting to `slice` an empty NodeList, so there's no need to query each element in the DOM.
