### PR TITLE
Update express.

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,7 @@
 var fs = require('fs');
 
 var express = require('express')
-  , app = express.createServer();
+  , app = express();
 
 app.use(function(req, res, next) {
   var setHeader = res.setHeader;


### PR DESCRIPTION
Express emits a deprecation warning when started, asking you to use
express() instead of express.createServer().  Follow its advice.
